### PR TITLE
Updated Dockerfile to use updated stirling-pdf image.

### DIFF
--- a/stirling_pdf/Dockerfile
+++ b/stirling_pdf/Dockerfile
@@ -1,5 +1,5 @@
 # Use the frooodle/s-pdf image as the base
-FROM frooodle/s-pdf:latest-fat
+FROM stirlingtools/stirling-pdf:latest-fat
 
 # Install Tini to manage processes
 RUN apk add --no-cache tini

--- a/stirling_pdf/config.yaml
+++ b/stirling_pdf/config.yaml
@@ -1,5 +1,5 @@
 name: "Stirling PDF"
-version: "1.0.0"
+version: "1.1.0"
 slug: "stirling_pdf"
 description: "Locally hosted web application for various PDF operations."
 arch:


### PR DESCRIPTION
The Stirling PDF docker hub repository has been migrated from the frooodle account to the stirling-pdf account.

Original: https://hub.docker.com/r/frooodle/s-pdf
New: https://hub.docker.com/r/stirlingtools/stirling-pdf

As far as I can see, the old repo is still getting updates but for the future they recommend to use the new link.